### PR TITLE
add ability to runtask to client and pass env overrides

### DIFF
--- a/provider/ecs/ecs.go
+++ b/provider/ecs/ecs.go
@@ -1138,9 +1138,18 @@ func (e *ECS) RunTask(clusterName, taskDefinition string, runTask service.RunTas
 	taskOverride := &ecs.TaskOverride{}
 	var containerOverrides []*ecs.ContainerOverride
 	for _, co := range runTask.ContainerOverrides {
+		// environment variables
+		var environment []*ecs.KeyValuePair
+		if len(co.Environment) > 0 {
+			for _, v := range co.Environment {
+				environment = append(environment, &ecs.KeyValuePair{Name: aws.String(v.Name), Value: aws.String(v.Value)})
+			}
+		}
+
 		containerOverrides = append(containerOverrides, &ecs.ContainerOverride{
 			Command: aws.StringSlice(co.Command),
 			Name:    aws.String(co.Name),
+			Environment: environment,
 		})
 	}
 	taskOverride.SetContainerOverrides(containerOverrides)

--- a/service/deploy.go
+++ b/service/deploy.go
@@ -177,8 +177,9 @@ type RunTask struct {
 	ContainerOverrides []RunTaskContainerOverride `json:"containerOverrides"`
 }
 type RunTaskContainerOverride struct {
-	Name    string   `json:"name"`
-	Command []string `json:"command"`
+	Name        string                        `json:"name"`
+	Command     []string                      `json:"command"`
+	Environment []*DeployContainerEnvironment `json:"environment"`
 }
 
 // create Autoscaling Policy


### PR DESCRIPTION
Hi @wardviaene, this is a little crude so feel free to push back if it needs some more user friendliness!

Adds a client command for `runtask` and adds on the service side the ability to pass through environment overrides for that task.