### PR TITLE
Optional Resource Creation + Add docker health check support

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,31 +2,24 @@
 
 
 [[projects]]
-  digest = "1:8e47871087b94913898333f37af26732faaab30cdb41571136cf7aec9921dae7"
   name = "github.com/PuerkitoBio/purell"
   packages = ["."]
-  pruneopts = ""
   revision = "0bcb03f4b4d0a9428594752bd2a3b9aa0a9d4bd4"
   version = "v1.1.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:331a419049c2be691e5ba1d24342fc77c7e767a80c666a18fd8a9f7b82419c1c"
   name = "github.com/PuerkitoBio/urlesc"
   packages = ["."]
-  pruneopts = ""
   revision = "de5bf2ad457846296e2031421a34e2568e304e35"
 
 [[projects]]
-  digest = "1:f29065f7fceb53501efaf08ec3c697009828a6cd1c221b5bfda8b139f669141f"
   name = "github.com/appleboy/gin-jwt"
   packages = ["."]
-  pruneopts = ""
   revision = "f7347d7c16fc8297bf5b7215b9e4847a5ca05d90"
   version = "v2.3.1"
 
 [[projects]]
-  digest = "1:02d2baadfb5aba340329a1d1fa09564090619330952508fb2eac63f69e1bab43"
   name = "github.com/aws/aws-sdk-go"
   packages = [
     "aws",
@@ -39,12 +32,18 @@
     "aws/credentials/ec2rolecreds",
     "aws/credentials/endpointcreds",
     "aws/credentials/stscreds",
+    "aws/crr",
+    "aws/csm",
     "aws/defaults",
     "aws/ec2metadata",
     "aws/endpoints",
     "aws/request",
     "aws/session",
     "aws/signer/v4",
+    "internal/ini",
+    "internal/sdkio",
+    "internal/sdkrand",
+    "internal/sdkuri",
     "internal/shareddefaults",
     "private/protocol",
     "private/protocol/ec2query",
@@ -68,318 +67,244 @@
     "service/elbv2",
     "service/iam",
     "service/ssm",
-    "service/sts",
+    "service/sts"
   ]
-  pruneopts = ""
-  revision = "0cebc639926eb91b0192dae4b28bc808417e764c"
-  version = "v1.12.61"
+  revision = "ceab7b7ac6f535d1397f124620720b5145f1ad59"
+  version = "v1.15.88"
 
 [[projects]]
-  digest = "1:a2470e727142c0fb8dbf6f230fb63cf8dc39da614b55c157ad31d27fbc40e033"
   name = "github.com/beevik/etree"
   packages = ["."]
-  pruneopts = ""
   revision = "15a30b44cfd6c5a16a7ddfe271bf146aaf2d3195"
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:1cf61f0228e64d1bfddaa42bfd1f5047ed3626925b9bea69bbcb9168472dae23"
   name = "github.com/cenkalti/backoff"
   packages = ["."]
-  pruneopts = ""
   revision = "61153c768f31ee5f130071d08fc82b85208528de"
   version = "v1.1.0"
 
 [[projects]]
-  digest = "1:7d18876d174c2f46e7005446b9ffd703e3861cebb790951d7911eeb0a1d87959"
   name = "github.com/crewjam/saml"
   packages = [
     ".",
     "logger",
     "samlsp",
-    "xmlenc",
+    "xmlenc"
   ]
-  pruneopts = ""
   revision = "6b5dd2d26974f7f5e59132ef5921fab7993794d7"
   version = "0.2.0"
 
 [[projects]]
-  digest = "1:3e93e899f8457138a891b3ccedcacf8fe9074865c848f7028e1892bdae280676"
   name = "github.com/dgrijalva/jwt-go"
   packages = ["."]
-  pruneopts = ""
   revision = "dbeaa9332f19a944acb5736b4456cfcc02140e29"
   version = "v3.1.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:c146a26992e821c711db2ae3255d2fe4c5efe8e70f543cee140c365dcf934883"
   name = "github.com/gin-contrib/location"
   packages = ["."]
-  pruneopts = ""
   revision = "5220ebf8be6c350431168cbd884f2c0ace0e3f4c"
 
 [[projects]]
   branch = "master"
-  digest = "1:1120f960f5c334f0f94bad29eefaf73d52d226893369693686148f66c1993f15"
   name = "github.com/gin-contrib/sse"
   packages = ["."]
-  pruneopts = ""
   revision = "22d885f9ecc78bf4ee5d72b937e4bbcdc58e8cae"
 
 [[projects]]
-  digest = "1:748df8eda48a48d6d05ebb848a6cf966f846fa4e6179f8731385d04d7a287fc1"
   name = "github.com/gin-gonic/gin"
   packages = [
     ".",
     "binding",
     "json",
-    "render",
+    "render"
   ]
-  pruneopts = ""
   revision = "b869fe1415e4b9eb52f247441830d502aece2d4d"
   version = "v1.3.0"
 
 [[projects]]
-  digest = "1:a00483fe4106b86fb1187a92b5cf6915c85f294ed4c129ccbe7cb1f1a06abd46"
-  name = "github.com/go-ini/ini"
-  packages = ["."]
-  pruneopts = ""
-  revision = "32e4c1e6bc4e7d0d8451aa6b75200d19e37a536a"
-  version = "v1.32.0"
-
-[[projects]]
   branch = "master"
-  digest = "1:1287439f7765209116509fffff2b8f853845e4b35572b41a1aadda42cbcffcc2"
   name = "github.com/go-openapi/jsonpointer"
   packages = ["."]
-  pruneopts = ""
   revision = "779f45308c19820f1a69e9a4cd965f496e0da10f"
 
 [[projects]]
   branch = "master"
-  digest = "1:07ac8ac445f68b0bc063d11845d479fb7e09c906ead7a8c4165b59777df09d74"
   name = "github.com/go-openapi/jsonreference"
   packages = ["."]
-  pruneopts = ""
   revision = "36d33bfe519efae5632669801b180bf1a245da3b"
 
 [[projects]]
   branch = "master"
-  digest = "1:7435955c77fff6ae276134b76e733060ccc144b0d70a69aa544fa036348ac788"
   name = "github.com/go-openapi/spec"
   packages = ["."]
-  pruneopts = ""
   revision = "fa03337d7da5735229ee8f5e9d5d0b996014b7f8"
 
 [[projects]]
   branch = "master"
-  digest = "1:366052ef634d344217d6720719c9f8e95de13a94d211f09785b0ba3c4c181b06"
   name = "github.com/go-openapi/swag"
   packages = ["."]
-  pruneopts = ""
   revision = "84f4bee7c0a6db40e3166044c7983c1c32125429"
 
 [[projects]]
   branch = "master"
-  digest = "1:3b760d3b93f994df8eb1d9ebfad17d3e9e37edcb7f7efaa15b427c0d7a64f4e4"
   name = "github.com/golang/protobuf"
   packages = ["proto"]
-  pruneopts = ""
   revision = "1e59b77b52bf8e4b449a57e6f79f21226d571845"
 
 [[projects]]
-  digest = "1:9ed055a3aae12576c784609f6894cc05ea64f24c3a4859f1d0052bfea1bdde0e"
   name = "github.com/google/go-cmp"
   packages = [
     "cmp",
     "cmp/internal/diff",
     "cmp/internal/function",
-    "cmp/internal/value",
+    "cmp/internal/value"
   ]
-  pruneopts = ""
   revision = "8099a9787ce5dc5984ed879a3bda47dc730a8e97"
   version = "v0.1.0"
 
 [[projects]]
-  digest = "1:20ed7daa9b3b38b6d1d39b48ab3fd31122be5419461470d0c28de3e121c93ecf"
   name = "github.com/gorilla/context"
   packages = ["."]
-  pruneopts = ""
   revision = "1ea25387ff6f684839d82767c1733ff4d4d15d0a"
   version = "v1.1"
 
 [[projects]]
-  digest = "1:1ff3509899d1357b533eefcc4be703aa4b8b690370de9bce65389aad226acf3c"
   name = "github.com/gorilla/securecookie"
   packages = ["."]
-  pruneopts = ""
   revision = "667fe4e3466a040b780561fe9b51a83a3753eefc"
   version = "v1.1"
 
 [[projects]]
-  digest = "1:bfb5530b06be15a20de32e6c946eddc2d81693980c79205bcda3bd37fe1a931c"
   name = "github.com/gorilla/sessions"
   packages = ["."]
-  pruneopts = ""
   revision = "ca9ada44574153444b00d3fd9c8559e4cc95f896"
   version = "v1.1"
 
 [[projects]]
   branch = "master"
-  digest = "1:4d056defc2ebde8b3f892d04b64a77d85ccd0952a50bdb99f4064b98739ca727"
   name = "github.com/guregu/dynamo"
   packages = [
     ".",
-    "internal/exprs",
+    "internal/exprs"
   ]
-  pruneopts = ""
   revision = "78f36f7876767b1899b4bac7381d109fe5a58539"
 
 [[projects]]
-  digest = "1:6f49eae0c1e5dab1dafafee34b207aeb7a42303105960944828c2079b92fc88e"
   name = "github.com/jmespath/go-jmespath"
   packages = ["."]
-  pruneopts = ""
   revision = "0b12d6b5"
 
 [[projects]]
-  digest = "1:302ad9379eb146668760df4d779a95379acab43ce5f9a28f27f3273f98232020"
   name = "github.com/jonboulle/clockwork"
   packages = ["."]
-  pruneopts = ""
   revision = "2eee05ed794112d45db504eb05aa693efd2b8b09"
   version = "v0.1.0"
 
 [[projects]]
-  digest = "1:416fb7f9304f3cae8e9951aa7dc7b9d5b3e341cc1dc987efd6ca1ed867e0d4f9"
   name = "github.com/json-iterator/go"
   packages = ["."]
-  pruneopts = ""
   revision = "f7279a603edee96fe7764d3de9c6ff8cf9970994"
   version = "1.0.4"
 
 [[projects]]
   branch = "master"
-  digest = "1:3be464a55a419d4c22383388f1204a9597c6cdc41d67ca4bc08848e688585279"
   name = "github.com/juju/loggo"
   packages = ["."]
-  pruneopts = ""
   revision = "8232ab8918d91c72af1a9fb94d3edbe31d88b790"
 
 [[projects]]
   branch = "master"
-  digest = "1:ccc20cacf54eb16464dad02efa1c14fa7c0b9e124639b0d2a51dcc87b0154e4c"
   name = "github.com/mailru/easyjson"
   packages = [
     "buffer",
     "jlexer",
-    "jwriter",
+    "jwriter"
   ]
-  pruneopts = ""
   revision = "32fa128f234d041f196a9f3e0fea5ac9772c08e1"
 
 [[projects]]
-  digest = "1:78229b46ddb7434f881390029bd1af7661294af31f6802e0e1bedaad4ab0af3c"
   name = "github.com/mattn/go-isatty"
   packages = ["."]
-  pruneopts = ""
   revision = "0360b2af4f38e8d38c7fce2a9f4e702702d73a39"
   version = "v0.0.3"
 
 [[projects]]
   branch = "master"
-  digest = "1:460694d16012aafeae0f6ed4bb4e7ad446e18099cb778e3c1e2d318f0192183b"
   name = "github.com/robbiet480/go.sns"
   packages = ["."]
-  pruneopts = ""
   revision = "208b4fd8d60f0d2f7ce3611ca193621a973d0f4c"
 
 [[projects]]
   branch = "master"
-  digest = "1:e8ca1dbc2cd5d1ca75a72ad3eb04634057566a3696363e954bb1a013c0fb7e03"
   name = "github.com/russellhaering/goxmldsig"
   packages = [
     ".",
     "etreeutils",
-    "types",
+    "types"
   ]
-  pruneopts = ""
   revision = "b7efc6231e45b10bfd779852831c8bb59b350ec5"
 
 [[projects]]
-  digest = "1:261bc565833ef4f02121450d74eb88d5ae4bd74bfe5d0e862cddb8550ec35000"
   name = "github.com/spf13/pflag"
   packages = ["."]
-  pruneopts = ""
   revision = "e57e3eeb33f795204c1ca35f56c44f83227c6e66"
   version = "v1.0.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:e439a53cc4290d4e7cd1419022e779c88b58e3e39b5f4c4b8f6c17a8f38188b9"
   name = "github.com/swaggo/gin-swagger"
   packages = [
     ".",
-    "swaggerFiles",
+    "swaggerFiles"
   ]
-  pruneopts = ""
   revision = "0ee1d2817cb324ab3f71e4cbd53e4edf8aeefab3"
 
 [[projects]]
-  digest = "1:6f727a09437e3b30fa9adfb7551d4bf12217ea21c3aa4718ed6cee7748ca7d9b"
   name = "github.com/swaggo/swag"
   packages = ["."]
-  pruneopts = ""
   revision = "acc3460bbe5b259414db5f61c8893eed2ace6a56"
   version = "v1.0.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:9924ebd2e0ff9b4c92cbb82838d776b5913295bcfeaffd5f3c36e55b845f1d7f"
   name = "github.com/ugorji/go"
   packages = ["codec"]
-  pruneopts = ""
   revision = "9831f2c3ac1068a78f50999a30db84270f647af6"
 
 [[projects]]
   branch = "master"
-  digest = "1:43adf91783cc814f60c0dd21c9aadf0b5284721e13542e124536638e0b43a6b3"
   name = "golang.org/x/crypto"
   packages = [
     "ripemd160",
-    "ssh/terminal",
+    "ssh/terminal"
   ]
-  pruneopts = ""
   revision = "13931e22f9e72ea58bb73048bc752b48c6d4d4ac"
 
 [[projects]]
   branch = "master"
-  digest = "1:f3ee2a699dd02cac37fbca1d028f1121ce0e48143a0f9abd293d3141dcfe6b92"
   name = "golang.org/x/net"
   packages = [
     "context",
     "idna",
     "webdav",
-    "webdav/internal/xml",
+    "webdav/internal/xml"
   ]
-  pruneopts = ""
   revision = "5ccada7d0a7ba9aeb5d3aca8d3501b4c2a509fec"
 
 [[projects]]
   branch = "master"
-  digest = "1:b22916910a1104a56a5a64a208de1f3f58e69cde1cca3229f8b54f531df1be69"
   name = "golang.org/x/sys"
   packages = [
     "unix",
-    "windows",
+    "windows"
   ]
-  pruneopts = ""
   revision = "810d7000345868fc619eb81f46307107118f4ae1"
 
 [[projects]]
   branch = "master"
-  digest = "1:9f9562b058a594dae0c8e2388c1a802664111736845bc08885246f0e4bf99bdd"
   name = "golang.org/x/text"
   packages = [
     "collate",
@@ -396,75 +321,31 @@
     "unicode/cldr",
     "unicode/norm",
     "unicode/rangetable",
-    "width",
+    "width"
   ]
-  pruneopts = ""
   revision = "e19ae1496984b1c655b8044a65c0300a3c878dd3"
 
 [[projects]]
-  digest = "1:3e93e899f8457138a891b3ccedcacf8fe9074865c848f7028e1892bdae280676"
   name = "gopkg.in/dgrijalva/jwt-go.v3"
   packages = ["."]
-  pruneopts = ""
   revision = "dbeaa9332f19a944acb5736b4456cfcc02140e29"
   version = "v3.1.0"
 
 [[projects]]
-  digest = "1:dd549e360e5a8f982a28c2bcbe667307ceffe538ed9afc7c965524f1ac285b3f"
   name = "gopkg.in/go-playground/validator.v8"
   packages = ["."]
-  pruneopts = ""
   revision = "5f1438d3fca68893a817e4a66806cea46a9e4ebf"
   version = "v8.18.2"
 
 [[projects]]
   branch = "v2"
-  digest = "1:4b4e5848dfe7f316f95f754df071bebfb40cf4482da62e17e7e1aebdf11f4918"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
-  pruneopts = ""
   revision = "d670f9405373e636a5a2765eea47fac0c9bc91a4"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  input-imports = [
-    "github.com/appleboy/gin-jwt",
-    "github.com/aws/aws-sdk-go/aws",
-    "github.com/aws/aws-sdk-go/aws/awserr",
-    "github.com/aws/aws-sdk-go/aws/credentials",
-    "github.com/aws/aws-sdk-go/aws/credentials/stscreds",
-    "github.com/aws/aws-sdk-go/aws/request",
-    "github.com/aws/aws-sdk-go/aws/session",
-    "github.com/aws/aws-sdk-go/service/acm",
-    "github.com/aws/aws-sdk-go/service/applicationautoscaling",
-    "github.com/aws/aws-sdk-go/service/autoscaling",
-    "github.com/aws/aws-sdk-go/service/cloudwatch",
-    "github.com/aws/aws-sdk-go/service/cloudwatchlogs",
-    "github.com/aws/aws-sdk-go/service/dynamodb",
-    "github.com/aws/aws-sdk-go/service/ec2",
-    "github.com/aws/aws-sdk-go/service/ecr",
-    "github.com/aws/aws-sdk-go/service/ecs",
-    "github.com/aws/aws-sdk-go/service/elbv2",
-    "github.com/aws/aws-sdk-go/service/iam",
-    "github.com/aws/aws-sdk-go/service/ssm",
-    "github.com/aws/aws-sdk-go/service/sts",
-    "github.com/crewjam/saml",
-    "github.com/crewjam/saml/samlsp",
-    "github.com/dgrijalva/jwt-go",
-    "github.com/gin-contrib/location",
-    "github.com/gin-gonic/gin",
-    "github.com/google/go-cmp/cmp",
-    "github.com/gorilla/context",
-    "github.com/gorilla/sessions",
-    "github.com/guregu/dynamo",
-    "github.com/juju/loggo",
-    "github.com/robbiet480/go.sns",
-    "github.com/spf13/pflag",
-    "github.com/swaggo/gin-swagger",
-    "github.com/swaggo/gin-swagger/swaggerFiles",
-    "github.com/swaggo/swag",
-    "golang.org/x/crypto/ssh/terminal",
-  ]
+  inputs-digest = "3718ce0a20b5553df48c650babcb80fceac1d888613307261f11590654ce8886"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -27,7 +27,7 @@
 
 [[constraint]]
   name = "github.com/aws/aws-sdk-go"
-  version = "1.12.61"
+  version = "1.15.88"
 
 [[constraint]]
   name = "github.com/crewjam/saml"

--- a/provider/ecs/ecs.go
+++ b/provider/ecs/ecs.go
@@ -293,6 +293,25 @@ func (e *ECS) CreateTaskDefinition(d service.Deploy) (*string, error) {
 			Image:        aws.String(imageUri),
 			DockerLabels: aws.StringMap(container.DockerLabels),
 		}
+
+		if len(container.HealthCheck.Command) > 0 {
+			healthCheck := &ecs.HealthCheck{
+				Command: container.HealthCheck.Command,
+			}
+			if container.HealthCheck.Interval > 0 {
+				healthCheck.SetInterval(container.HealthCheck.Interval)
+			}
+			if container.HealthCheck.Retries > 0 {
+				healthCheck.SetRetries(container.HealthCheck.Retries)
+			}
+			if container.HealthCheck.StartPeriod > 0 {
+				healthCheck.SetStartPeriod(container.HealthCheck.StartPeriod)
+			}
+			if container.HealthCheck.Timeout > 0 {
+				healthCheck.SetTimeout(container.HealthCheck.Timeout)
+			}
+			containerDefinition.SetHealthCheck(healthCheck)
+		}
 		// set containerPort if not empty
 		if container.ContainerPort > 0 {
 			containerDefinition.SetPortMappings([]*ecs.PortMapping{

--- a/service/deploy.go
+++ b/service/deploy.go
@@ -42,6 +42,7 @@ type DeployContainer struct {
 	CPU               int64                         `json:"cpu"`
 	CPUReservation    int64                         `json:"cpuReservation"`
 	DockerLabels      map[string]string             `json:"dockerLabels"`
+	HealthCheck       DeployContainerHealthCheck    `json:"healthCheck"`
 	Environment       []*DeployContainerEnvironment `json:"environment"`
 	MountPoints       []*DeployContainerMountPoint  `json:"mountPoints"`
 	Ulimits           []*DeployContainerUlimit      `json:"ulimits"`
@@ -59,6 +60,13 @@ type DeployContainerMountPoint struct {
 	ContainerPath string `json:"containerPath"`
 	SourceVolume  string `json:"sourceVolume"`
 	ReadOnly      bool   `json:"readonly"`
+}
+type DeployContainerHealthCheck struct {
+	Command     []*string `json:"command"`
+	Interval    int64     `json:"interval"`
+	Timeout     int64     `json:"timeout"`
+	Retries     int64     `json:"retries"`
+	StartPeriod int64     `json:"startPeriod"`
 }
 type DeployNetworkConfiguration struct {
 	AssignPublicIp string   `json:"assignPublicIp"`


### PR DESCRIPTION
Hi @wardviaene !

Just a few changes to:
- Make resource creation optional, we have a use case where we would like to still use ecs-deploy to do the glue between ci and ecs, but have resources completely managed outside of it. I did it based on a new Env variable `AWS_RESOURCE_CREATION_ENABLED`, let me know if you think of another better way
- Support an additional attribute in the container definitions [`healthCheck`](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#container_definition_healthcheck). I had to update aws-sdk to support this one

