### PR TITLE
Bug fixes

### DIFF
--- a/api/controller.go
+++ b/api/controller.go
@@ -120,9 +120,8 @@ func (c *Controller) Deploy(serviceName string, d service.Deploy) (*service.Depl
 				controllerLogger.Errorf("Could not create service %v in dynamodb", serviceName)
 				return nil, err
 			}
-		} else {
-			c.updateDeployment(d, ddLast, serviceName, taskDefArn, iamRoleArn)
 		}
+		c.updateDeployment(d, ddLast, serviceName, taskDefArn, iamRoleArn)
 	}
 
 	// Mark previous deployment as aborted if still running

--- a/api/controller.go
+++ b/api/controller.go
@@ -80,6 +80,8 @@ func (c *Controller) Deploy(serviceName string, d service.Deploy) (*service.Depl
 					return nil, err
 				}
 			}
+		} else {
+			return nil, errors.New("IAM Task Role not found and resource creation is disabled")
 		}
 	} else if err != nil {
 		return nil, err

--- a/service/service.go
+++ b/service/service.go
@@ -212,6 +212,20 @@ func (s *Service) CreateService(dsElement *DynamoServicesElement) error {
 	}
 	return nil
 }
+func (s *Service) ServiceExistsInDynamo() (bool, error) {
+	var ds DynamoServices
+	err := s.GetServices(&ds)
+	if err != nil {
+		serviceLogger.Errorf(err.Error())
+		return false, err
+	}
+	for _, a := range ds.Services {
+		if a.S == s.ServiceName {
+			return true, nil
+		}
+	}
+	return false, nil
+}
 func (s *Service) NewDeployment(taskDefinitionArn *string, d *Deploy) (*DynamoDeployment, error) {
 	day := time.Now().Format("2006-01-02")
 	month := time.Now().Format("2006-01")


### PR DESCRIPTION
Hi @wardviaene !
Here is a couple of fixes to bugs that we introduced with the resource creation flag:
- Error handling when IAM Task role doesn't exist but resource creation is disabled
- Error handling when ECS Service doesn't exist but resource creation is disabled
- Bug when the ecs service do exists (was created externally) but the service doesn't exist yet in dynamodb, fixed by adding another check
- moving the parameter-store namespace update block out of the condition that checks if service protocol is none, since this can be updated totally independently of it